### PR TITLE
Remove normalize-css from the list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ The callback receives an object of the form `{editable: true/false}`. The value 
 Add to the `<head>` of your gadget's `versal.html`:
 
 ```
-  <link rel="stylesheet" href="bower_components/normalize-css/normalize.css">
   <link rel="stylesheet" href="bower_components/versal-gadget-api/versal-gadget-theme.css">
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,7 @@
   ],
   "dependencies": {
     "eventEmitter": "~4.2.7",
-    "underscore": "~1.6.0",
-    "normalize-css": "~3.0.1"
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "versal-component-runtime": "~0.2.1"


### PR DESCRIPTION
It is now build in versal-gadget-theme