### PR TITLE
Add version and name to satisfy npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "versal-gadget-api",
+  "version": "0.0.9",
   "repository": "https://github.com/Versal/versal-gadget-api",
   "scripts": {
     "test": "npm run build && karma start --browsers Firefox --single-run",


### PR DESCRIPTION
Nice because it allows simpler usage with browserify/webpack. Not nice because it means we need to bump versions in `{package,bower}.json`. I think it's worth the tradeoff, if so do we want any small script or command(s) in `package.json` -> `scripts`?

I won't be bothered if you shoot down the whole PR by closing, no biggy. Thanks!