### PR TITLE
Don’t use browserify’s standalone method

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "npm run build && karma start --browsers Firefox --single-run",
     "build": "npm run buildStyles && npm run buildScripts",
     "buildStyles": "myth -c styles/index.css versal-gadget-theme.css",
-    "buildScripts": "browserify src/player-api.js -o versal-player-api.js -s VersalPlayerAPI"
+    "buildScripts": "browserify src/player-api.js -o versal-player-api.js"
   },
   "devDependencies": {
     "browserify": "^8.1.1",

--- a/src/player-api.js
+++ b/src/player-api.js
@@ -173,3 +173,5 @@ PlayerAPI.prototype.assetUrl = function(id){
 };
 
 module.exports = PlayerAPI;
+
+window.VersalPlayerAPI = PlayerAPI;

--- a/versal-player-api.js
+++ b/versal-player-api.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.VersalPlayerAPI=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -478,5 +478,6 @@ PlayerAPI.prototype.assetUrl = function(id){
 
 module.exports = PlayerAPI;
 
-},{"events":1}]},{},[2])(2)
-});
+window.VersalPlayerAPI = PlayerAPI;
+
+},{"events":1}]},{},[2]);


### PR DESCRIPTION
This interferes with requirejs in the legacy launcher. Instead we just manually export VersalPlayerAPI