### PR TITLE
Ensure body has overflow of hidden

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -21,12 +21,9 @@
   --sans-serif: 'Open sans', sans-serif;
 }
 
-html {
+html, body {
   overflow: hidden;
   word-wrap: break-word;
-}
-
-body {
   background: var(--white);
   color: var(--gray);
 }


### PR DESCRIPTION
Fixes issue when touch scrolling doesn't work in Safari when cursor is over iframe gadget.

Essentially, all iframe gadgets must have `body { overflow: hidden; }`. We set it in `versal-gadget-theme.css` and assume gadget developers use that.